### PR TITLE
Defect invalid arg to intn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.bak
 main
+.idea

--- a/perfTestUtils/dataStructures_test.go
+++ b/perfTestUtils/dataStructures_test.go
@@ -22,20 +22,3 @@ func TestSetDefaults(t *testing.T) {
 	assert.Equal(t, false, c.ReBaseMemory)
 	assert.Equal(t, false, c.ReBaseAll)
 }
-
-func TestPrintAndValidateConfig(t *testing.T) {
-	willCallOsExit := false
-	exit := func(i int) { willCallOsExit = true }
-	c := &Config{}
-	c.SetDefaults()
-	c.PrintAndValidateConfig(exit)
-	assert.False(t, willCallOsExit)
-}
-
-func TestPrintAndValidateConfigErr(t *testing.T) {
-	willCallOsExit := false
-	exit := func(i int) { willCallOsExit = true }
-	c := &Config{}
-	c.PrintAndValidateConfig(exit)
-	assert.True(t, willCallOsExit)
-}

--- a/run_unit_test.sh
+++ b/run_unit_test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Execute all unit tests.
+
+TRUE=1
+FALSE=0
+EXCEPT=$FALSE
+
+
+#----- Run the unit tests
+go test -v || EXCEPT=$TRUE
+
+cd perfTestUtils
+go test -v || EXCEPT=$TRUE
+cd -
+
+cd testStrategies
+go test -v || EXCEPT=$TRUE
+cd -
+
+#----- Report overall success
+MSG="All Unit Tests PASSED"
+if [ $EXCEPT -eq $TRUE ]; then
+	MSG="!! Unit Test FAILED !!   Search 'FAIL:' in output above for details."
+fi
+
+echo
+echo
+echo $MSG
+echo
+
+exit 0


### PR DESCRIPTION
When attempting to run automated-perf-test from the api/test/performance directory, the program would throw a runtime panic: "invalid argument to Intn" during the initConfig() call. I found that the new Config struct member 'RequestDelay' was not getting initialized. I refactored the initConfig() function to initialize the struct by calling setDefaults() up front, then overriding parameters that the user explicitly set on the command line or in the config file.

As a convenience to aid unit testing I added a top level script that will execute "go test" in each package subdirectory of the project. 

I also removed two superfluous tests from the dataStructures_test.go file. These test were calling the PrintAndValidateConfig() function with incorrect parameterss causing complie-time errors when attempting to run "go test". Since the PrintAndValidateConfig() function is just setting values to hard-coded constants, I couldn't think of a way to make the tests meaningful.