### PR TITLE
Updated utils.go to create the output directory if it doesn't exist.

### DIFF
--- a/perfTestUtils/ReportGenerator.go
+++ b/perfTestUtils/ReportGenerator.go
@@ -106,7 +106,16 @@ func (p *perfStatsModel) JsonTimeArray() template.JS {
 }
 
 func GenerateTemplateReport(basePerfstats *BasePerfStats, perfStats *PerfStats, configurationSettings *Config, fs FileSystem, testSuiteName string) {
-	file, err := fs.Create(configurationSettings.ReportOutputDir + "/PerformanceReport-" + configurationSettings.APIName + "-" + testSuiteName + ".html")
+	// Check for existence of output dir and create if needed.
+	err := os.MkdirAll( configurationSettings.ReportOutputDir, os.ModePerm )
+	if err != nil {
+		// Non-fatal error. Don't exit.
+		log.Errorf( "Failed to create path: [%s]. Error: %s\n", configurationSettings.ReportOutputDir, err )
+	}
+
+	filename := "PerformanceReport-" + configurationSettings.APIName + "-" + testSuiteName + ".html"
+
+	file, err := fs.Create( configurationSettings.ReportOutputDir + "/" + filename )
 	if err != nil {
 		log.Errorf("Error creating report file: %v", err)
 	}

--- a/perfTestUtils/utils.go
+++ b/perfTestUtils/utils.go
@@ -306,13 +306,22 @@ func GenerateEnvBasePerfOutputFile(perfStatsForTest *PerfStats, basePerfstats *B
 	//Set base performance based on training test run
 	populateBasePerfStats(perfStatsForTest, basePerfstats, configurationSettings.ReBaseMemory)
 
-	//Convert base perf stat to Json and write out to file
+	//Convert base perf stat to Json
 	basePerfstatsJson, err := json.Marshal(basePerfstats)
 	if err != nil {
 		log.Error("Failed to marshal to Json. Error:", err)
 		exit(1)
 	}
-	file, err := fs.Create(configurationSettings.BaseStatsOutputDir + "/" + configurationSettings.ExecutionHost + "-" + testSuiteName + "-perfBaseStats")
+
+	// Check for existence of output dir and create if needed.
+	if os.MkdirAll( configurationSettings.BaseStatsOutputDir, os.ModePerm ); err != nil {
+		log.Errorf( "Failed to create path: [%s]. Error: %s\n", configurationSettings.BaseStatsOutputDir, err )
+		exit(1)
+	}
+
+	// Write base perf stat to file.
+	file_name := configurationSettings.ExecutionHost + "-" + testSuiteName + "-perfBaseStats"
+	file, err := fs.Create( configurationSettings.BaseStatsOutputDir + "/" + file_name )
 	if err != nil {
 		log.Error("Failed to create output file. Error:", err)
 		exit(1)


### PR DESCRIPTION
Since the config file provides the baseStatsOutputDir it makes sense to create it if it doesn't exist rather than make the directory creation a separate initialization step the user has to worry about. If the directory creation fails, the user will get an error and the program will abort since there is not much point running the tests if the program is unable to update the metrics. 