### PR TITLE
Feature suite based mods

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,9 +104,10 @@ func main() {
 	//Generate a test suite based on configuration settings
 	testSuite := new(testStrategies.TestSuite)
 	testSuite.BuildTestSuite(configurationSettings)
+	numTestCases := len( testSuite.TestCases ) //convenience variable
 
 	if checkTestReadyness {
-		readyForTest, _ := perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name)
+		readyForTest, _ := perfTestUtils.IsReadyForTest( configurationSettings, osFileSystem, testSuite.Name, numTestCases )
 		if !readyForTest {
 			log.Info("System is not ready for testing.")
 			os.Exit(1)
@@ -121,7 +122,7 @@ func main() {
 		if configurationSettings.ReBaseAll {
 			runInTrainingMode(configurationSettings.ExecutionHost, true, testSuite)
 		} else {
-			readyForTest, _ := perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name)
+			readyForTest, _ := perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name, numTestCases)
 			if !readyForTest {
 				runInTrainingMode(configurationSettings.ExecutionHost, false, testSuite)
 			} else {
@@ -129,13 +130,13 @@ func main() {
 			}
 		}
 	} else {
-		readyForTest, basePerfStats := perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name)
+		readyForTest, basePerfStats := perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name, numTestCases)
 		if readyForTest {
 			runInTestingMode(basePerfStats, configurationSettings.ExecutionHost, perfTestUtils.GenerateTemplateReport, testSuite)
 		} else {
 			log.Info("System is not ready for testing. Attempting to run training mode....")
 			runInTrainingMode(configurationSettings.ExecutionHost, false, testSuite)
-			readyForTest, basePerfStats = perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name)
+			readyForTest, basePerfStats = perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name, numTestCases)
 			if readyForTest {
 				runInTestingMode(basePerfStats, configurationSettings.ExecutionHost, perfTestUtils.GenerateTemplateReport, testSuite)
 			} else {

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 	numTestCases := len( testSuite.TestCases ) //convenience variable
 
 	if checkTestReadyness {
-		readyForTest, _ := perfTestUtils.IsReadyForTest( configurationSettings, osFileSystem, testSuite.Name, numTestCases )
+		readyForTest, _ := perfTestUtils.IsReadyForTest( configurationSettings, testSuite.Name, numTestCases )
 		if !readyForTest {
 			log.Info("System is not ready for testing.")
 			os.Exit(1)
@@ -122,7 +122,7 @@ func main() {
 		if configurationSettings.ReBaseAll {
 			runInTrainingMode(configurationSettings.ExecutionHost, true, testSuite)
 		} else {
-			readyForTest, _ := perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name, numTestCases)
+			readyForTest, _ := perfTestUtils.IsReadyForTest(configurationSettings, testSuite.Name, numTestCases)
 			if !readyForTest {
 				runInTrainingMode(configurationSettings.ExecutionHost, false, testSuite)
 			} else {
@@ -130,13 +130,13 @@ func main() {
 			}
 		}
 	} else {
-		readyForTest, basePerfStats := perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name, numTestCases)
+		readyForTest, basePerfStats := perfTestUtils.IsReadyForTest(configurationSettings, testSuite.Name, numTestCases)
 		if readyForTest {
 			runInTestingMode(basePerfStats, configurationSettings.ExecutionHost, perfTestUtils.GenerateTemplateReport, testSuite)
 		} else {
 			log.Info("System is not ready for testing. Attempting to run training mode....")
 			runInTrainingMode(configurationSettings.ExecutionHost, false, testSuite)
-			readyForTest, basePerfStats = perfTestUtils.IsReadyForTest(configurationSettings, osFileSystem, testSuite.Name, numTestCases)
+			readyForTest, basePerfStats = perfTestUtils.IsReadyForTest(configurationSettings, testSuite.Name, numTestCases)
 			if readyForTest {
 				runInTestingMode(basePerfStats, configurationSettings.ExecutionHost, perfTestUtils.GenerateTemplateReport, testSuite)
 			} else {
@@ -338,7 +338,7 @@ func runAssertions(basePerfstats *perfTestUtils.BasePerfStats, perfStats *perfTe
 		}
 
 		responseTimeVariancePercentage := perfTestUtils.CalcAverageResponseVariancePercentage(averageServiceResponseTime, baseResponseTime)
-		varianceOk := perfTestUtils.ValidateAverageServiceResponeTimeVariance(configurationSettings.AllowableServiceResponseTimeVariance, responseTimeVariancePercentage, serviceName)
+		varianceOk := perfTestUtils.ValidateAverageServiceResponseTimeVariance(configurationSettings.AllowableServiceResponseTimeVariance, responseTimeVariancePercentage, serviceName)
 		if !varianceOk {
 			assertionFailures = append(assertionFailures, fmt.Sprintf("Service Failure: Service test %-60s response time variance exceeded by %3.2f %1s", serviceName, responseTimeVariancePercentage, "%"))
 		}

--- a/perfTestUtils/ReportGenerator.go
+++ b/perfTestUtils/ReportGenerator.go
@@ -106,7 +106,16 @@ func (p *perfStatsModel) JsonTimeArray() template.JS {
 }
 
 func GenerateTemplateReport(basePerfstats *BasePerfStats, perfStats *PerfStats, configurationSettings *Config, fs FileSystem, testSuiteName string) {
-	file, err := fs.Create(configurationSettings.ReportOutputDir + "/PerformanceReport-" + configurationSettings.APIName + "-" + testSuiteName + ".html")
+	// Check for existence of output dir and create if needed.
+	err := os.MkdirAll( configurationSettings.ReportOutputDir, os.ModePerm )
+	if err != nil {
+		// Non-fatal error. Don't exit.
+		log.Errorf( "Failed to create path: [%s]. Error: %s\n", configurationSettings.ReportOutputDir, err )
+	}
+
+	filename := "PerformanceReport-" + configurationSettings.APIName + "-" + testSuiteName + ".html"
+
+	file, err := fs.Create( configurationSettings.ReportOutputDir + "/" + filename )
 	if err != nil {
 		log.Errorf("Error creating report file: %v", err)
 	}

--- a/perfTestUtils/utils.go
+++ b/perfTestUtils/utils.go
@@ -74,7 +74,7 @@ func GetExecutionTimeDisplay(executionTime int64) string {
 	return string(displayStatement)
 }
 
-func IsReadyForTest(configurationSettings *Config, osFileSystem OsFS, testSuiteName string, numTestCases int) (bool, *BasePerfStats) {
+func IsReadyForTest(configurationSettings *Config, testSuiteName string, numTestCases int) (bool, *BasePerfStats) {
 	//1) read in perf base stats
 	f, err := os.Open(configurationSettings.BaseStatsOutputDir + "/" + configurationSettings.ExecutionHost + "-" + testSuiteName + "-perfBaseStats")
 	if err != nil {
@@ -236,7 +236,7 @@ func ValidatePeakMemoryVariance(allowablePeakMemoryVariance float64, peakMemoryV
 	}
 }
 
-func ValidateAverageServiceResponeTimeVariance(allowableServiceResponseTimeVariance float64, serviceResponseTimeVariancePercentage float64, serviceName string) bool {
+func ValidateAverageServiceResponseTimeVariance(allowableServiceResponseTimeVariance float64, serviceResponseTimeVariancePercentage float64, serviceName string) bool {
 	if allowableServiceResponseTimeVariance >= serviceResponseTimeVariancePercentage {
 		return true
 	} else {

--- a/perfTestUtils/utils.go
+++ b/perfTestUtils/utils.go
@@ -306,13 +306,22 @@ func GenerateEnvBasePerfOutputFile(perfStatsForTest *PerfStats, basePerfstats *B
 	//Set base performance based on training test run
 	populateBasePerfStats(perfStatsForTest, basePerfstats, configurationSettings.ReBaseMemory)
 
-	//Convert base perf stat to Json and write out to file
+	//Convert base perf stat to Json
 	basePerfstatsJson, err := json.Marshal(basePerfstats)
 	if err != nil {
 		log.Error("Failed to marshal to Json. Error:", err)
 		exit(1)
 	}
-	file, err := fs.Create(configurationSettings.BaseStatsOutputDir + "/" + configurationSettings.ExecutionHost + "-" + testSuiteName + "-perfBaseStats")
+
+	// Check for existence of output dir and create if needed.
+	if os.MkdirAll( configurationSettings.BaseStatsOutputDir, os.ModePerm ); err != nil {
+		log.Errorf( "Failed to create path: [%s]. Error: %s\n", configurationSettings.BaseStatsOutputDir, err )
+		exit(1)
+	}
+
+	// Write base perf stat to file.
+	file_name := configurationSettings.ExecutionHost + "-" + testSuiteName + "-perfBaseStats"
+	file, err := fs.Create( configurationSettings.BaseStatsOutputDir + "/" + file_name )
 	if err != nil {
 		log.Error("Failed to create output file. Error:", err)
 		exit(1)

--- a/perfTestUtils/utils.go
+++ b/perfTestUtils/utils.go
@@ -57,31 +57,6 @@ func ReadBasePerfFile(r io.Reader) (*BasePerfStats, error) {
 	return basePerfstats, errorFound
 }
 
-func ValidateTestDefinitionAmount(baselineAmount int, configurationSettings *Config, fs FileSystem) bool {
-
-	d, err := fs.Open(configurationSettings.TestCaseDir)
-	if err != nil {
-		log.Error("Failed to open test definitions directory. Error:", err)
-		os.Exit(1)
-	}
-	defer d.Close()
-	fi, err := d.Readdir(-1)
-	if err != nil {
-		log.Error("Failed to read files in test definitions directory. Error:", err)
-		os.Exit(1)
-	}
-
-	definitionAmount := len(fi)
-
-	log.Info("Number of defined test cases:", definitionAmount)
-	log.Info("Number of base line test cases:", baselineAmount)
-	if definitionAmount != baselineAmount {
-		log.Error(fmt.Sprintf("Amount of test definition: %d does not equal to baseline amount: %d.\n", definitionAmount, baselineAmount))
-		return false
-	}
-	return true
-}
-
 func GetExecutionTimeDisplay(executionTime int64) string {
 	timeInMilliSeconds := executionTime / 1000000
 	seconds := (timeInMilliSeconds / 1000)
@@ -99,8 +74,7 @@ func GetExecutionTimeDisplay(executionTime int64) string {
 	return string(displayStatement)
 }
 
-func IsReadyForTest(configurationSettings *Config, osFileSystem OsFS, testSuiteName string) (bool, *BasePerfStats) {
-
+func IsReadyForTest(configurationSettings *Config, osFileSystem OsFS, testSuiteName string, numTestCases int) (bool, *BasePerfStats) {
 	//1) read in perf base stats
 	f, err := os.Open(configurationSettings.BaseStatsOutputDir + "/" + configurationSettings.ExecutionHost + "-" + testSuiteName + "-perfBaseStats")
 	if err != nil {
@@ -119,9 +93,20 @@ func IsReadyForTest(configurationSettings *Config, osFileSystem OsFS, testSuiteN
 		log.Error("Base Perf stats are not fully populated for  " + configurationSettings.ExecutionHost + ".")
 		return false, nil
 	}
+
 	//3) Verify the number of base test cases is equal to the number of service test cases.
-	correctNumberOfTests := ValidateTestDefinitionAmount(len(basePerfstats.BaseServiceResponseTimes), configurationSettings, osFileSystem)
-	if !correctNumberOfTests {
+	baselineAmount := len( basePerfstats.BaseServiceResponseTimes )
+	log.Info( "Number of defined test cases:", numTestCases )
+	log.Info( "Number of base line test cases:", baselineAmount )
+
+	if baselineAmount != numTestCases {
+		log.Error(
+			fmt.Sprintf(
+				"Amount of test definition: %d does not equal to baseline amount: %d.\n",
+				numTestCases,
+				baselineAmount,
+			),
+		)
 		return false, nil
 	}
 

--- a/perfTestUtils/utils_test.go
+++ b/perfTestUtils/utils_test.go
@@ -84,22 +84,6 @@ func TestReadBasePerfFileErrUnmarshal(t *testing.T) {
 	assert.Equal(t, `invalid character 'e' in literal true (expecting 'r')`, err.Error())
 }
 
-func TestValidateTestDefinitionAmount(t *testing.T) {
-	c := &Config{
-		TestCaseDir: "mockDir",
-	}
-	valid := ValidateTestDefinitionAmount(10, c, mockedFs)
-	assert.True(t, valid)
-}
-
-func TestValidateTestDefinitionAmountFail(t *testing.T) {
-	c := &Config{
-		TestCaseDir: "mockDir",
-	}
-	valid := ValidateTestDefinitionAmount(100, c, mockedFs)
-	assert.False(t, valid)
-}
-
 func TestCalcPeakMemoryVariancePercentage(t *testing.T) {
 	vp := CalcPeakMemoryVariancePercentage(100, 110)
 	assert.Equal(t, float64(10), vp)
@@ -185,9 +169,9 @@ func TestValidatePeakMemoryVariance(t *testing.T) {
 }
 
 func TestValidateAverageServiceResponeTimeVariance(t *testing.T) {
-	assert.True(t, ValidateAverageServiceResponeTimeVariance(15, 10, "test"))
-	assert.True(t, ValidateAverageServiceResponeTimeVariance(15, 15, "test"))
-	assert.False(t, ValidateAverageServiceResponeTimeVariance(15, 16, "test"))
+	assert.True(t, ValidateAverageServiceResponseTimeVariance(15, 10, "test"))
+	assert.True(t, ValidateAverageServiceResponseTimeVariance(15, 15, "test"))
+	assert.False(t, ValidateAverageServiceResponseTimeVariance(15, 16, "test"))
 }
 
 func TestGenerateEnvBasePerfOutputFile(t *testing.T) {

--- a/testStrategies/commonToAllTestStrategies.go
+++ b/testStrategies/commonToAllTestStrategies.go
@@ -90,10 +90,11 @@ type multipartFormField struct {
 
 func (ts *TestSuite) BuildTestSuite(configurationSettings *perfTestUtils.Config) {
 	log.Info("Building Test Suite ....")
+	// Default to ServiceBased testing:
+	ts.TestStrategy = SERVICE_BASED_TESTING
 
 	if configurationSettings.TestSuite == "" {
 		ts.Name = "DefaultSuite"
-		ts.TestStrategy = SERVICE_BASED_TESTING
 
 		//If no test suite has been defined, treat and all test case files as the suite
 		d, err := os.Open(configurationSettings.TestCaseDir)
@@ -128,6 +129,9 @@ func (ts *TestSuite) BuildTestSuite(configurationSettings *perfTestUtils.Config)
 			ts.TestCases = append(ts.TestCases, testDefinition)
 		}
 	} else {
+		// Flag as SuiteBased testing:
+		ts.TestStrategy = SUITE_BASED_TESTING
+
 		//If a test suite has been defined, load in all tests associated with the test suite.
 		bs, err := ioutil.ReadFile(configurationSettings.TestSuiteDir + "/" + configurationSettings.TestSuite)
 		if err != nil {


### PR DESCRIPTION
This update changes the way the IsReadyForTest() validation function counts the number of test cases to compare with the number of data points from the output directory. Previously, the function validated between output data points and files in the definition directory. This left a discrepancy in cases where the suite definition contained less test cases than there were files in the test case definition directory. In these cases training mode would run correctly, but the output data points would remain less than the number of files in the test case directory. This implementation bases the test case count off the length of the testSuite.TestCases instance, which exists in both suite-based and service-based test modes.
