### PR TITLE
Defect substitute requestvals

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func initConfig(args []string, fs perfTestUtils.FileSystem, exit func(code int))
 	// Args that override default options in Config struct:
 	flag.BoolVar(&configurationSettings.GBS, "gbs", false, "Generate 'Base Statistics' for this server")
 	flag.BoolVar(&configurationSettings.ReBaseMemory, "reBaseMemory", false, "Generate new base peak memory for this server")
-	flag.BoolVar(&configurationSettings.ReBaseAll, "reBaseAll", false, "Generate new base for memory and service resposne times for this server")
+	flag.BoolVar(&configurationSettings.ReBaseAll, "reBaseAll", false, "Generate new base for memory and service response times for this server")
 	flag.StringVar(&configurationSettings.ConfigFileFormat, "configFileFormat", "xml", "The format of the configuration file {xlm, toml}")
 	flag.StringVar(&configurationSettings.TestFileFormat, "testFileFormat", "xml", "The format of the test definition file {xlm, toml}")
 	flag.CommandLine.Parse(args)

--- a/testStrategies/commonToAllTestStrategies.go
+++ b/testStrategies/commonToAllTestStrategies.go
@@ -233,7 +233,7 @@ func (testDefinition *TestDefinition) BuildAndSendRequest(
 			//Retrieve Payload and perform any necessary substitution
 			payload := testDefinition.Payload
 			newPayload := substituteRequestValues(&payload, uniqueTestRunId, globalsMap)
-
+			reqbody = newPayload
 			req, _ = http.NewRequest(testDefinition.HttpMethod, "http://"+targetHost+":"+targetPort+requestBaseURI, strings.NewReader(newPayload))
 		} else {
 			req, _ = http.NewRequest(testDefinition.HttpMethod, "http://"+targetHost+":"+targetPort+requestBaseURI, nil)
@@ -408,7 +408,7 @@ func extractResponseValues(testCaseName string, body []byte, responseValues []Re
 	} else if strings.Contains(contentType, "xml") {
 		extractXMLResponseValues(testCaseName, body, responseValues, uniqueTestRunId, globalsMap)
 	} else {
-		log.Warn("Unsupported resposne content type of:", contentType)
+		log.Warn("Unsupported response content type of:", contentType)
 	}
 }
 

--- a/testStrategies/commonToAllTestStrategies.go
+++ b/testStrategies/commonToAllTestStrategies.go
@@ -270,7 +270,7 @@ func (testDefinition *TestDefinition) BuildAndSendRequest(
 	}
 
 	log.Debugf(
-		"BEGIN \"%s\" Request:\n-----\nHEADER:%+v\nURL:%s\nBODY:%s\n-----\nEND [%s] Request",
+		"BEGIN \"%s\" Request:\n-----\nHEADER:%+v\nURL:%s\nREQ_BODY:%s\n-----\nEND [%s] Request",
 		testDefinition.TestName,
 		req.Header,
 		req.URL,
@@ -293,7 +293,7 @@ func (testDefinition *TestDefinition) BuildAndSendRequest(
 	defer resp.Body.Close()
 
 	log.Debugf(
-		"BEGIN \"%s\" Response:\n-----\nSTATUSCODE:%d\nHEADER:%+v\nBODY:%s\n-----\nEND [%s] Response",
+		"BEGIN \"%s\" Response:\n-----\nSTATUSCODE:%d\nHEADER:%+v\nRESP_BODY:%s\n-----\nEND [%s] Response",
 		testDefinition.TestName,
 		resp.StatusCode,
 		resp.Header,

--- a/testStrategies/commonToAllTestStrategies.go
+++ b/testStrategies/commonToAllTestStrategies.go
@@ -403,6 +403,11 @@ func convertStoredValuetoRequestFormat(storedValue interface{}, requiredIndex in
 }
 
 func extractResponseValues(testCaseName string, body []byte, responseValues []ResponseValue, uniqueTestRunId string, globalsMap GlobalsMaps, contentType string) {
+	// Short-circuit if call returned empty response bodys.
+	if string(body) == "" {
+		return
+	}
+
 	if strings.Contains(contentType, "json") {
 		extractJSONResponseValues(testCaseName, body, responseValues, uniqueTestRunId, globalsMap)
 	} else if strings.Contains(contentType, "xml") {

--- a/testStrategies/commonToAllTestStrategies.go
+++ b/testStrategies/commonToAllTestStrategies.go
@@ -355,7 +355,7 @@ func substituteRequestValues(requestBody *string, uniqueTestRunId string, global
 	globalsMap.RUnlock()
 
 	if testRunGlobals != nil {
-		r := regexp.MustCompile("{{(.[^ ]+)?}}")
+		r := regexp.MustCompile("{{([^}]+)}}")
 		res := r.FindAllString(*requestBody, -1)
 
 		if len(res) > 0 {


### PR DESCRIPTION
XAPI-1232 Modified the regex pattern to allow multiple RequestValue variable substitutions on the same line. The previous implementation required a space to exist somewhere between the RequestValue variables, which would not allow for multiple substitutions in a querystring. 

Even though a simple "lazy" pattern match will work (eg. "{{(.*?)}}"), we went with a regex pattern that uses a negated character class to avoid the backtrack that would incur a cost across many concurrent iterations. See line  358 of the testStrategies/commonToAllTestStrategies.go file below. 

Lines 406-410 of the  testStrategies/commonToAllTestStrategies.go file eliminates unnecessary WARN messages for calls that do not return a BODY tag.

The other changes are to clarify log message output and to fix typos.