### PR TITLE
Corrected typos causing build failure.

### DIFF
--- a/perfTestUtils/utils_test.go
+++ b/perfTestUtils/utils_test.go
@@ -200,7 +200,7 @@ func TestGenerateEnvBasePerfOutputFile(t *testing.T) {
 	willCallOsExit := false
 	exit := func(i int) { willCallOsExit = true }
 
-	GenerateEnvBasePerfOutputFile(ps, bs, &Config{ReBaseMemory: true, BaseStatsOutputDir: "env", TargetHost: "localhost"}, exit, mockedFs, "TestSuiteName")
+	GenerateEnvBasePerfOutputFile(ps, bs, &Config{ReBaseMemory: true, BaseStatsOutputDir: "env", TargetHost: "localhost"}, exit, mockedFs)
 	assert.False(t, willCallOsExit)
 }
 
@@ -230,7 +230,7 @@ func TestGenerateEnvBasePerfOutputFileFailCreate(t *testing.T) {
 	willCallOsExit := false
 	exit := func(i int) { willCallOsExit = true }
 
-	GenerateEnvBasePerfOutputFile(ps, bs, &Config{ReBaseMemory: true, BaseStatsOutputDir: "env", ExecutionHost: "FAIL"}, exit, mockedFs, "TestSuiteName")
+	GenerateEnvBasePerfOutputFile(ps, bs, &Config{ReBaseMemory: true, BaseStatsOutputDir: "env", ExecutionHost: "FAIL"}, exit, mockedFs)
 	assert.True(t, willCallOsExit)
 }
 

--- a/testStrategies/suiteBasedTesting.go
+++ b/testStrategies/suiteBasedTesting.go
@@ -166,7 +166,7 @@ func executeTestSuite(
 		// Variables and properties for this iteration are no longer needed
 		// now that the iteration has completed.
 		mu.Lock()
-		GlobalsMap[uniqueTestRunID] = nil
+		globalsMap[uniqueTestRunID] = nil
 		mu.Unlock()
 	}
 


### PR DESCRIPTION
The renaming of GlobalsMaps must have been a late change that slipped through.