### PR TITLE
XAPTC-69  Consistent ValidateHeaderAndName function in Golang

### DIFF
--- a/uiServices/src/configServices.go
+++ b/uiServices/src/configServices.go
@@ -126,7 +126,17 @@ func getConfigs(rw http.ResponseWriter, req *http.Request) {
 	configPathDir := getConfigHeader(req)
 	configName := chi.URLParam(req, "configName")
 
-	if !ValidateFileNameAndHeader(rw, req, configPathDir, configName) {
+	// if !ValidateFileNameAndHeader(rw, req, configPathDir, configName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(configPathDir); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(configName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -172,7 +182,17 @@ func putConfigs(rw http.ResponseWriter, req *http.Request) {
 	path := getConfigHeader(req)
 	configName := chi.URLParam(req, "configName")
 
-	if !ValidateFileNameAndHeader(rw, req, path, configName) {
+	// if !ValidateFileNameAndHeader(rw, req, path, configName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(path); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(configName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -213,10 +233,18 @@ func putConfigFileName(rw http.ResponseWriter, req *http.Request) {
 	configFileName := chi.URLParam(req, "configFileName")
 	newConfigFileName := chi.URLParam(req, "newConfigFileName")
 
-	if !IsHeaderValid(newConfigFileName, rw) {
+	if err := IsHeaderValid(path); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	if !IsHeaderValid(configFileName, rw) {
+
+	if err := IsNameValid(configFileName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(newConfigFileName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/uiServices/src/configServices.go
+++ b/uiServices/src/configServices.go
@@ -27,26 +27,25 @@ func getConfigHeader(req *http.Request) string {
 	return configPathDir
 }
 
-func ValidateFileNameAndHeader(rw http.ResponseWriter, req *http.Request, header, name string) bool {
-	return IsNameValid(name, rw) && IsHeaderValid(header, rw)
-}
+// func ValidateRequest(header string, name string) error {
+// 	 IsNameValid(name)
+// 	 IsHeaderValid(header)
+// }
 
-func IsHeaderValid(header string, rw http.ResponseWriter) bool {
+func IsHeaderValid(header string) error {
 	if len(header) <= 1 {
 		logrus.Error("No Header Path Found")
-		rw.WriteHeader(http.StatusBadRequest)
-		return false
+		return fmt.Errorf("No Header Path Found")
 	}
-	return true
+	return nil
 }
 
-func IsNameValid(name string, rw http.ResponseWriter) bool {
+func IsNameValid(name string) error {
 	if len(name) < 1 {
 		logrus.Error("File Name is Empty")
-		rw.WriteHeader(http.StatusBadRequest)
-		return false
+		return fmt.Errorf("File Name is Empty")
 	}
-	return true
+	return nil
 }
 
 func IsPathDirValid(name string, rw http.ResponseWriter) bool {
@@ -226,7 +225,7 @@ func putConfigFileName(rw http.ResponseWriter, req *http.Request) {
 
 	err := os.Rename(configFilePath, newConfigFilePath)
 	if err != nil {
-		logrus.Println("File was not updated", err)
+		logrus.Error("File was not updated", err)
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/uiServices/src/configServices.go
+++ b/uiServices/src/configServices.go
@@ -28,15 +28,21 @@ func getConfigHeader(req *http.Request) string {
 }
 
 func ValidateFileNameAndHeader(rw http.ResponseWriter, req *http.Request, header, name string) bool {
+	return IsNameValid(name, rw) && IsHeaderValid(header, rw)
+}
 
-	if len(name) < 1 {
-		logrus.Error("File Name is Empty")
+func IsHeaderValid(header string, rw http.ResponseWriter) bool {
+	if len(header) <= 1 {
+		logrus.Error("No Header Path Found")
 		rw.WriteHeader(http.StatusBadRequest)
 		return false
 	}
+	return true
+}
 
-	if len(header) <= 1 {
-		logrus.Error("No Header Path Found")
+func IsNameValid(name string, rw http.ResponseWriter) bool {
+	if len(name) < 1 {
+		logrus.Error("File Name is Empty")
 		rw.WriteHeader(http.StatusBadRequest)
 		return false
 	}
@@ -190,6 +196,22 @@ func putConfigs(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+func putConfigFileName(rw http.ResponseWriter, req *http.Request) {
+	path := getConfigHeader(req)
+	configFileName := chi.URLParam(req, "configFileName")
+	newConfigFileName := chi.URLParam(req, "newConfigFileName")
+
+	if len(newConfigFileName) < 1 {
+		logrus.Error("File path does not exist")
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	os.Rename(fmt.Sprintf("%s%s.xml", path, configFileName), fmt.Sprintf("%s%s.xml", path, newConfigFileName))
 
 	rw.WriteHeader(http.StatusNoContent)
 }

--- a/uiServices/src/configServices.go
+++ b/uiServices/src/configServices.go
@@ -27,11 +27,6 @@ func getConfigHeader(req *http.Request) string {
 	return configPathDir
 }
 
-// func ValidateRequest(header string, name string) error {
-// 	 IsNameValid(name)
-// 	 IsHeaderValid(header)
-// }
-
 func IsHeaderValid(header string) error {
 	if len(header) <= 1 {
 		logrus.Error("No Header Path Found")
@@ -106,7 +101,7 @@ func postConfigs(rw http.ResponseWriter, req *http.Request) {
 		return
 
 	}
-	//Create file once checks are complete
+
 	if !configWriterXML(config, configPathDir+config.APIName+".xml") {
 
 		rw.WriteHeader(http.StatusInternalServerError)
@@ -125,10 +120,6 @@ func getConfigs(rw http.ResponseWriter, req *http.Request) {
 
 	configPathDir := getConfigHeader(req)
 	configName := chi.URLParam(req, "configName")
-
-	// if !ValidateFileNameAndHeader(rw, req, configPathDir, configName) {
-	// 	return
-	// }
 
 	if err := IsHeaderValid(configPathDir); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
@@ -181,10 +172,6 @@ func getConfigs(rw http.ResponseWriter, req *http.Request) {
 func putConfigs(rw http.ResponseWriter, req *http.Request) {
 	path := getConfigHeader(req)
 	configName := chi.URLParam(req, "configName")
-
-	// if !ValidateFileNameAndHeader(rw, req, path, configName) {
-	// 	return
-	// }
 
 	if err := IsHeaderValid(path); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)

--- a/uiServices/src/configServices_test.go
+++ b/uiServices/src/configServices_test.go
@@ -141,7 +141,6 @@ func TestValidJsonPost(t *testing.T) {
 	reader := strings.NewReader(validJSON)
 	r.HandleFunc("/configs", postConfigs)
 
-	//remove file if exists
 	os.Remove(os.Getenv("GOPATH") + "/src/github.com/xtracdev/automated-perf-test/uiServices/test/ServiceTestConfig.xml")
 
 	filePath := os.Getenv("GOPATH") + "/src/github.com/xtracdev/automated-perf-test/uiServices/test"
@@ -167,7 +166,6 @@ func TestPostWithOneCharName(t *testing.T) {
 	reader := strings.NewReader(validJsonWithOneCharName)
 	r.HandleFunc("/configs", postConfigs)
 
-	//remove file if exists
 	os.Remove(os.Getenv("GOPATH") + "/src/github.com/xtracdev/automated-perf-test/uiServices/test/x.xml")
 
 	filePath := os.Getenv("GOPATH") + "/src/github.com/xtracdev/automated-perf-test/uiServices/test"
@@ -270,7 +268,6 @@ func TestSuccessfulGet(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, request)
 
-	//prepare GET request
 	filePath = os.Getenv("GOPATH") + "/src/github.com/xtracdev/automated-perf-test/uiServices/test/"
 	request, err = http.NewRequest(http.MethodGet, "/configs/ServiceTestConfig", nil)
 
@@ -294,7 +291,7 @@ func TestSuccessfulGetPathWihoutSlash(t *testing.T) {
 	r.Mount("/", GetIndexPage())
 
 	r.HandleFunc("/configs", getConfigs)
-	//no slash at end of filepath header
+
 	filePath := os.Getenv("GOPATH") + "/src/github.com/xtracdev/automated-perf-test/uiServices/test"
 	request, err := http.NewRequest(http.MethodGet, "/configs/ServiceTestConfig", nil)
 

--- a/uiServices/src/testCaseServices.go
+++ b/uiServices/src/testCaseServices.go
@@ -134,12 +134,6 @@ func getAllTestCases(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// if len(testCasePathDir) <= 1 {
-	// 	logrus.Error("No file directory entered")
-	// 	rw.WriteHeader(http.StatusBadRequest)
-	// 	return
-	// }
-
 	files, err := ioutil.ReadDir(testCasePathDir)
 	if err != nil {
 		logrus.Error(err)

--- a/uiServices/src/testCaseServices.go
+++ b/uiServices/src/testCaseServices.go
@@ -53,7 +53,17 @@ func postTestCase(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCase.TestName) {
+	// if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCase.TestName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(testCasePathDir); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(testCase.TestName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -83,7 +93,16 @@ func putTestCase(rw http.ResponseWriter, req *http.Request) {
 	path := getTestCaseHeader(req)
 	testCaseName := chi.URLParam(req, "testCaseName")
 
-	if !ValidateFileNameAndHeader(rw, req, path, testCaseName) {
+	// if !ValidateFileNameAndHeader(rw, req, path, testCaseName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(path); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err := IsNameValid(testCaseName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -192,7 +211,17 @@ func getTestCase(rw http.ResponseWriter, req *http.Request) {
 	testCasePathDir := getTestCaseHeader(req)
 	testCaseName := chi.URLParam(req, "testCaseName")
 
-	if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCaseName) {
+	// if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCaseName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(testCasePathDir); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(testCaseName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -244,7 +273,17 @@ func deleteTestCase(rw http.ResponseWriter, req *http.Request) {
 	testCasePathDir := getTestCaseHeader(req)
 	testCaseName := chi.URLParam(req, "testCaseName")
 
-	if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCaseName) {
+	// if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCaseName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(testCasePathDir); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(testCaseName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/uiServices/src/testCaseServices.go
+++ b/uiServices/src/testCaseServices.go
@@ -53,10 +53,6 @@ func postTestCase(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCase.TestName) {
-	// 	return
-	// }
-
 	if err := IsHeaderValid(testCasePathDir); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
@@ -92,10 +88,6 @@ func postTestCase(rw http.ResponseWriter, req *http.Request) {
 func putTestCase(rw http.ResponseWriter, req *http.Request) {
 	path := getTestCaseHeader(req)
 	testCaseName := chi.URLParam(req, "testCaseName")
-
-	// if !ValidateFileNameAndHeader(rw, req, path, testCaseName) {
-	// 	return
-	// }
 
 	if err := IsHeaderValid(path); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
@@ -211,10 +203,6 @@ func getTestCase(rw http.ResponseWriter, req *http.Request) {
 	testCasePathDir := getTestCaseHeader(req)
 	testCaseName := chi.URLParam(req, "testCaseName")
 
-	// if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCaseName) {
-	// 	return
-	// }
-
 	if err := IsHeaderValid(testCasePathDir); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
@@ -272,10 +260,6 @@ func getTestCase(rw http.ResponseWriter, req *http.Request) {
 func deleteTestCase(rw http.ResponseWriter, req *http.Request) {
 	testCasePathDir := getTestCaseHeader(req)
 	testCaseName := chi.URLParam(req, "testCaseName")
-
-	// if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCaseName) {
-	// 	return
-	// }
 
 	if err := IsHeaderValid(testCasePathDir); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)

--- a/uiServices/src/testCaseServices.go
+++ b/uiServices/src/testCaseServices.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/Sirupsen/logrus"
-	"github.com/go-chi/chi"
-	"github.com/xtracdev/automated-perf-test/testStrategies"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/go-chi/chi"
+	"github.com/xtracdev/automated-perf-test/testStrategies"
 )
 
 const testCaseSchema string = "testCase_schema.json"
@@ -128,11 +129,16 @@ func putTestCase(rw http.ResponseWriter, req *http.Request) {
 func getAllTestCases(rw http.ResponseWriter, req *http.Request) {
 
 	testCasePathDir := getTestCaseHeader(req)
-	if len(testCasePathDir) <= 1 {
-		logrus.Error("No file directory entered")
-		rw.WriteHeader(http.StatusBadRequest)
+
+	if !IsPathDirValid(testCasePathDir, rw) {
 		return
 	}
+
+	// if len(testCasePathDir) <= 1 {
+	// 	logrus.Error("No file directory entered")
+	// 	rw.WriteHeader(http.StatusBadRequest)
+	// 	return
+	// }
 
 	files, err := ioutil.ReadDir(testCasePathDir)
 	if err != nil {
@@ -243,6 +249,7 @@ func getTestCase(rw http.ResponseWriter, req *http.Request) {
 func deleteTestCase(rw http.ResponseWriter, req *http.Request) {
 	testCasePathDir := getTestCaseHeader(req)
 	testCaseName := chi.URLParam(req, "testCaseName")
+
 	if !ValidateFileNameAndHeader(rw, req, testCasePathDir, testCaseName) {
 		return
 	}

--- a/uiServices/src/testCaseServices_test.go
+++ b/uiServices/src/testCaseServices_test.go
@@ -1,13 +1,14 @@
 package services
 
 import (
-	"github.com/go-chi/chi"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/assert"
 )
 
 const validTestCase = `

--- a/uiServices/src/testSuiteServices.go
+++ b/uiServices/src/testSuiteServices.go
@@ -182,7 +182,9 @@ func getTestSuite(rw http.ResponseWriter, req *http.Request) {
 	testSuitePathDir := getTestSuiteHeader(req)
 	testSuiteName := chi.URLParam(req, "testSuiteName")
 
-	ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName)
+	if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName){
+		return
+	}
 
 	file, err := os.Open(fmt.Sprintf("%s%s.xml", testSuitePathDir, testSuiteName))
 	if err != nil {

--- a/uiServices/src/testSuiteServices.go
+++ b/uiServices/src/testSuiteServices.go
@@ -57,7 +57,17 @@ func postTestSuites(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuite.Name) {
+	// if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuite.Name) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(testSuitePathDir); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(testSuite.Name); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -114,7 +124,17 @@ func putTestSuites(rw http.ResponseWriter, req *http.Request) {
 	path := getTestSuiteHeader(req)
 	testSuiteName := chi.URLParam(req, "testSuiteName")
 
-	if !ValidateFileNameAndHeader(rw, req, path, testSuiteName) {
+	// if !ValidateFileNameAndHeader(rw, req, path, testSuiteName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(path); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(testSuiteName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -155,7 +175,17 @@ func deleteTestSuite(rw http.ResponseWriter, req *http.Request) {
 	testSuitePathDir := getTestSuiteHeader(req)
 	testSuiteName := chi.URLParam(req, "testSuiteName")
 
-	if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName) {
+	// if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(testSuitePathDir); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := IsNameValid(testSuiteName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -191,7 +221,7 @@ func getTestSuite(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if  err:= IsNameValid(testSuiteName); err != nil {
+	if err := IsNameValid(testSuiteName); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/uiServices/src/testSuiteServices.go
+++ b/uiServices/src/testSuiteServices.go
@@ -182,7 +182,17 @@ func getTestSuite(rw http.ResponseWriter, req *http.Request) {
 	testSuitePathDir := getTestSuiteHeader(req)
 	testSuiteName := chi.URLParam(req, "testSuiteName")
 
-	if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName) {
+	// if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName) {
+	// 	return
+	// }
+
+	if err := IsHeaderValid(testSuitePathDir); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if  err:= IsNameValid(testSuiteName); err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/uiServices/src/testSuiteServices.go
+++ b/uiServices/src/testSuiteServices.go
@@ -57,10 +57,6 @@ func postTestSuites(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuite.Name) {
-	// 	return
-	// }
-
 	if err := IsHeaderValid(testSuitePathDir); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
@@ -124,10 +120,6 @@ func putTestSuites(rw http.ResponseWriter, req *http.Request) {
 	path := getTestSuiteHeader(req)
 	testSuiteName := chi.URLParam(req, "testSuiteName")
 
-	// if !ValidateFileNameAndHeader(rw, req, path, testSuiteName) {
-	// 	return
-	// }
-
 	if err := IsHeaderValid(path); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
@@ -175,10 +167,6 @@ func deleteTestSuite(rw http.ResponseWriter, req *http.Request) {
 	testSuitePathDir := getTestSuiteHeader(req)
 	testSuiteName := chi.URLParam(req, "testSuiteName")
 
-	// if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName) {
-	// 	return
-	// }
-
 	if err := IsHeaderValid(testSuitePathDir); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
@@ -211,10 +199,6 @@ func getTestSuite(rw http.ResponseWriter, req *http.Request) {
 
 	testSuitePathDir := getTestSuiteHeader(req)
 	testSuiteName := chi.URLParam(req, "testSuiteName")
-
-	// if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName) {
-	// 	return
-	// }
 
 	if err := IsHeaderValid(testSuitePathDir); err != nil {
 		rw.WriteHeader(http.StatusBadRequest)

--- a/uiServices/src/testSuiteServices.go
+++ b/uiServices/src/testSuiteServices.go
@@ -182,7 +182,7 @@ func getTestSuite(rw http.ResponseWriter, req *http.Request) {
 	testSuitePathDir := getTestSuiteHeader(req)
 	testSuiteName := chi.URLParam(req, "testSuiteName")
 
-	if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName){
+	if !ValidateFileNameAndHeader(rw, req, testSuitePathDir, testSuiteName) {
 		return
 	}
 


### PR DESCRIPTION
Changed all remaining instances of "ValidateHeaderAndName" to "if !ValidateHeaderAndName{ return}" for consistency. There was only one instance that was left to be changed.